### PR TITLE
Fixed typo calling mime.getTypes

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -319,7 +319,7 @@ class BackslideCli {
         if (!cache[url]) {
           try {              
             const b = fs.readFileSync(url);
-            cache[url] = `data:${mime.getType()(match[2])};base64,${b.toString('base64')}`;
+            cache[url] = `data:${mime.getType(match[2])};base64,${b.toString('base64')}`;
           } catch (e) {
             console.error(e.message);
           }


### PR DESCRIPTION
This should fix #41 looks like a typo in the function call. 