### PR TITLE
Fix for spaces in paths

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -112,10 +112,10 @@ class BackslideCli {
           exportedFiles.push(exportedFile);
           child.execSync([
               'node',
-              require.resolve('decktape'),
+              `"${require.resolve('decktape')}"`,
               `-p ${wait}`,
               `file://${path.resolve(file)}`,
-              path.join(output, exportedFile),
+              `"${path.join(output, exportedFile)}"`,
               ...options
             ].join(' '), {
               stdio: verbose ? [1, 2] : [2]


### PR DESCRIPTION
Re #31, this possibly prevents issues where there is a space in the path to the source document, or to the `decktape` installation. 

I haven't found it necessary to `encodeURI` the file path