### PR TITLE
Split and reassamble markdown at </script>

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -250,6 +250,11 @@ class BackslideCli {
       });
   }
 
+  _splitMd(md) {
+    var v = JSON.stringify(md);
+    return v.split(/(?!<)\/(?=script>)/gm).join('/" + "');
+  }
+
   _exportFile(dir, file, stripNotes, stripFragments, fixRelativePath, inline) {
     let html, md;
     const filename = path.basename(file, path.extname(file)) + '.html';
@@ -285,7 +290,7 @@ class BackslideCli {
           css = this._makePathRelativeTo(css.toString(), TemplateDir, [CssRelativeURLRegExp]);
         }
         return Mustache.render(html, {
-          source: `source: ${JSON.stringify(md)}`,
+          source: `source: ${this._splitMd(md)}`,
           style: `<style>\n${css}\n</style>`,
           title: this._getTitle(md) || path.basename(file, path.extname(file))
         })

--- a/backslide.js
+++ b/backslide.js
@@ -251,7 +251,7 @@ class BackslideCli {
   }
 
   _splitMd(md) {
-    var v = JSON.stringify(md);
+    const v = JSON.stringify(md);
     return v.split(/(?!<)\/(?=script>)/gm).join('/" + "');
   }
 


### PR DESCRIPTION
After JSON.stringifying the whole md, it is cut in chunks at the / in
each </script>, and reassambled as sum of strings. For example if the
resulting string would be:

    "This contains <script>foo</script> tags"

It would be converted to:

    "This cointains <script>foo<" + "/script> tags"

The resulting string is the same, but being cut this way the browser is
no longer confused by the `</script>` inside the code.