### PR TITLE
doc & template: Mention usage of Yarn as a NPM-alternative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ See an example presentation [here](https://sinedied.github.io/backslide)
 
 ## Installation
 
-### NPM
+### NPM/Yarn
 
 ```sh
 npm install -g backslide
+# or
+yarn add backslide
 ```
 
 ### Docker

--- a/example/index.md
+++ b/example/index.md
@@ -64,9 +64,12 @@ class: middle
 - **Prerequisites**: [NodeJS](https://nodejs.org) v7.6+
 
 ```sh
+# create project directory
+$ mkdir my-presentation && cd my-presentation
+# install globally with NPM
 $ npm install -g backslide
-$ mkdir my-presentation
-$ cd my-presentation
+# or use yarn locally
+$ yarn add backslide
 $ bs init
 $ bs serve
 ```

--- a/example/index.md
+++ b/example/index.md
@@ -68,8 +68,8 @@ class: middle
 $ mkdir my-presentation && cd my-presentation
 # install globally with NPM
 $ npm install -g backslide
-# or use yarn locally
-$ yarn add backslide
+# or Yarn
+$ yarn global add backslide
 $ bs init
 $ bs serve
 ```


### PR DESCRIPTION
Hi Yohan,

I'd tried to install, for testing, backslide with NPM and failed miserably (Ubuntu 19.04, NodeJS 10, NPM 6.9), but had some success with [Yarn](https://yarnpkg.com/en/). So I decided to list it as an alternative to NPM in both README and https://sinedied.github.io/backslide/ .

Please feel free to pull this small change, adapt it, rewrite it all, or ignore it ;-)

V.F.