### PR TITLE
Fix unescaped spaces in source paths

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -114,7 +114,7 @@ class BackslideCli {
               'node',
               `"${require.resolve('decktape')}"`,
               `-p ${wait}`,
-              `file://${path.resolve(file)}`,
+              `"file://${path.resolve(file)}"`,
               `"${path.join(output, exportedFile)}"`,
               ...options
             ].join(' '), {


### PR DESCRIPTION
When creating a PDF from a presentation, spaces in the path to the HTML file previously lead to failure ("An error occurred during pdf conversion").

This commit adds quotation marks to prevent the command line invocation of decktape from failing when called with paths that contain spaces.

Fixes #31 (The PR for #48 did not fix this).