### PR TITLE
doc: Fix missing mention of Dektape additional options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Commands:
     -o, --output          Output directory                     [default: pdf]
     -w, --wait            Wait time between slides in ms       [default: 1000]
     --verbose             Show Decktape console output
+    -- [Decktape opts]    Pass any Decktape options directly
 ```
 
 ### Creating a new presentation


### PR DESCRIPTION
Hi sinedied,

Searching for setting custom parameters to Decktape (e.g. `--size`), and reading source code of backslide, I found that... passing additional options is already provided by backslide. But it is not documented in README.md, which content is not in sync. with its `help` content.
So this short and trivial pull-request aims to fix that ;-) 