### PR TITLE
Fixes a broken PDF export and an XSS vulnerability when using multiple script tags in a Markdown code block

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -422,7 +422,7 @@ class BackslideCli {
   }
 
   _escapeScript(md) {
-    return md.replace('</script>', '<\\/script>');
+    return md.replace(new RegExp('</script>', 'g'), '<\\/script>');
   }
 
   _help() {


### PR DESCRIPTION
Fixes #61 by escaping all ocurrences of `</script>`, not just the first.