### PR TITLE
Use web-resource-inliner instead of inliner.

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra')
 const glob = require('glob');
 const Mustache = require('mustache');
 const sass = require('node-sass');
-const Inliner = require('inliner');
+const Inliner = require('web-resource-inliner');
 const Progress = require('progress');
 const browserSync = require('browser-sync').create('bs-server');
 const mime = require('mime');
@@ -334,13 +334,9 @@ class BackslideCli {
   _inline(basedir, html) {
     return new Promise((resolve, reject) => {
       process.chdir(basedir);
-      new Inliner({
-        source: html,
-        inlinemin: true,
-        // Must be disabled because it's buggy, see https://github.com/remy/inliner/issues/63
-        collapseWhitespace: false
-      },
-      (err, html) => err ? reject(err) : resolve(html));
+      Inliner.html({
+        fileContent: html
+      }, (err, html) => err ? reject(err) : resolve(html));
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
     "decktape": "^2.9.3",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
-    "inliner": "^1.13.1",
+    "web-resource-inliner": "^4.3.4",
     "mime": "^2.4.4",
     "minimist": "^1.2.0",
     "mustache": "^3.1.0",
     "node-sass": "^4.12.0",
     "progress": "^2.0.3",
+    "sass": "^1.23.7",
     "update-notifier": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
web-resource-inliner has fine-grained control for ignoring certain resources, which inliner does not provide.

It would be really nice to have this level of control in backslide so that users can easily control what to inline and what not to when exporting slides. In my use case, I want to ensure webfonts are *not* inline, but everything else should be inlined.