### PR TITLE
Inline CSS images from template dir

### DIFF
--- a/backslide.js
+++ b/backslide.js
@@ -286,7 +286,7 @@ class BackslideCli {
       })
       .then(css => {
         if (inline) {
-          return this._inlineCss(dirname, dir, css);
+          return this._inlineCss(path.join(dirname, TemplateDir), dir, css);
         }
       })
       .then(css => {


### PR DESCRIPTION
The css is the template and all referenced images should be in the template directory. This path loads them correctly. Would fix bug #76