### PR TITLE
fix: update node-sass package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mime": "^2.4.5",
     "minimist": "^1.2.5",
     "mustache": "^4.0.1",
-    "node-sass": "^4.14.1",
+    "node-sass": "^5.0.0",
     "progress": "^2.0.3",
     "update-notifier": "^4.1.0",
     "web-resource-inliner": "^4.3.4"


### PR DESCRIPTION
This pull request proposes to upgrade the node-sass package to 5.0 to make it compatible [1] with the most recent Node.js release (v15).
According to [1] this version of node-sass should also be compatible with Node.js 14 which is the current LTS [2].

[1] https://github.com/sass/node-sass
[2] https://nodejs.org/en/about/releases/