### PR TITLE
Bumped node-sass from version 5.0.0 to version 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mime": "^2.4.5",
     "minimist": "^1.2.5",
     "mustache": "^4.0.1",
-    "node-sass": "^5.0.0",
+    "node-sass": "^6.0.1",
     "progress": "^2.0.3",
     "update-notifier": "^5.0.1",
     "web-resource-inliner": "^5.0.0"


### PR DESCRIPTION
node-sass version is outdated, making it impossible to install the package on node version 16. See: https://www.npmjs.com/package/node-sass